### PR TITLE
Fix hellaswag import in train script

### DIFF
--- a/train.py
+++ b/train.py
@@ -8,7 +8,7 @@ import math
 import time
 import numpy as np
 import os
-from hellaswag import render_example, iterate_examples
+from hellaswag_eval import render_example, iterate_examples
 
 
 class CausalSelfAttention(nn.Module):


### PR DESCRIPTION
## Summary
- fix module import for HellaSwag utilities

## Testing
- `python train.py` *(fails: shape '[32, 1024]' is invalid)*
- `python hellaswag_eval.py -m gpt2 -d cpu` *(interrupted after start)*

------
https://chatgpt.com/codex/tasks/task_e_6841656c5cc48327a0086daede592979